### PR TITLE
vanir_config 2.1

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -385,6 +385,13 @@ arm_objects_cflags :=
 normal_objects_cflags :=
 endif
 
+# Workaround issues with fstrict-aliasing until properly fixed.
+ifeq ($(USE_FSTRICT_FLAGS),true)
+  ifeq ($(LOCAL_MODULE),$(filter $(LOCAL_MODULE),$(VANIR_SPECIAL_CASE_MODULES)))
+    LOCAL_CFLAGS += $(call cc-option,-fno-strict-aliasing)
+  endif
+endif
+
 ###########################################################
 ## Define per-module debugging flags.  Users can turn on
 ## debugging for a particular module by setting DEBUG_MODULE_ModuleName

--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -67,7 +67,7 @@ $(combo_2nd_arch_prefix)TARGET_STRIP := $($(combo_2nd_arch_prefix)TARGET_TOOLS_P
 
 $(combo_2nd_arch_prefix)TARGET_NO_UNDEFINED_LDFLAGS := -Wl,--no-undefined
 
-$(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    -O2 \
+$(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    $(VANIR_ARM_OPT_LEVEL) \
                         -fomit-frame-pointer \
                         -fstrict-aliasing    \
                         -funswitch-loops \
@@ -76,7 +76,7 @@ $(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    -O2 \
 
 # Modules can choose to compile some source as thumb.
 $(combo_2nd_arch_prefix)TARGET_thumb_CFLAGS :=  -mthumb \
-                        -Os \
+                        $(VANIR_THUMB_OPT_LEVEL) \
                         -fomit-frame-pointer \
                         -fno-strict-aliasing \
                         $(VANIR_FSTRICT_OPTIONS) \
@@ -150,7 +150,7 @@ $(combo_2nd_arch_prefix)TARGET_GLOBAL_CPPFLAGS += -fvisibility-inlines-hidden
 # More flags/options can be added here
 $(combo_2nd_arch_prefix)TARGET_RELEASE_CFLAGS := \
 			-DNDEBUG \
-			-g \
+			-g0 \
 			-Wstrict-aliasing=2 \
 			-fgcse-after-reload \
 			-frerun-cse-after-loop \

--- a/core/combo/select.mk
+++ b/core/combo/select.mk
@@ -49,9 +49,9 @@ $(combo_var_prefix)HAVE_STRLCPY := 0
 $(combo_var_prefix)HAVE_STRLCAT := 0
 $(combo_var_prefix)HAVE_KERNEL_MODULES := 0
 
-$(combo_var_prefix)GLOBAL_CFLAGS := -fno-exceptions -Wno-multichar
-$(combo_var_prefix)RELEASE_CFLAGS := -O2 -g -fno-strict-aliasing
-$(combo_var_prefix)GLOBAL_CPPFLAGS :=
+$(combo_var_prefix)GLOBAL_CFLAGS := $(VANIR_GLOBAL_CFLAGS) -fno-exceptions -Wno-multichar
+$(combo_var_prefix)RELEASE_CFLAGS := $(VANIR_ARM_OPT_LEVEL) $(VANIR_RELEASE_CFLAGS) -fno-strict-aliasing
+$(combo_var_prefix)GLOBAL_CPPFLAGS := $(VANIR_GLOBAL_CPPFLAGS)
 $(combo_var_prefix)GLOBAL_LDFLAGS :=
 $(combo_var_prefix)GLOBAL_ARFLAGS := crsPD
 $(combo_var_prefix)GLOBAL_LD_DIRS :=

--- a/core/vanir_config.mk
+++ b/core/vanir_config.mk
@@ -29,7 +29,9 @@
 # USE_EXTRA_CLANG_FLAGS := true allows additional flags to be passed to the Clang compiler
 # ADDITIONAL_TARGET_ARM_OPT := Additional flags may be appended here for GCC-specific modules, -O3 etc
 # ADDITIONAL_TARGET_THUMB_OPT := Additional flags may be appended here for GCC-specific modules, -O3 etc
-# FSTRICT_ALIASING_WARNING_LEVEL := 0-3 for what is considered an aliasing violation
+# VANIR_ARM_OPT_LEVEL := -Ox for TARGET_arm_CFLAGS, preserved in binary.mk
+# VANIR_THUMB_OPT_LEVEL := -Ox for TARGET_thumb_CFLAGS, preserved in binary.mk
+# USE_LOCAL_WARNING_OVERRIDES := true will apply set flags only in listed modules. Designed for to turn off specific werrors.
 
 # SET GLOBAL CONFIGURATION HERE:
 MAXIMUM_OVERDRIVE           ?= true
@@ -41,9 +43,14 @@ USE_BINARY_FLAGS            ?=
 USE_EXTRA_CLANG_FLAGS       ?=
 ADDITIONAL_TARGET_ARM_OPT   ?=
 ADDITIONAL_TARGET_THUMB_OPT ?=
+VANIR_ARM_OPT_LEVEL         ?= -O2
+VANIR_THUMB_OPT_LEVEL       ?= -Os
 FSTRICT_ALIASING_WARNING_LEVEL ?= 2
 
+# Set some defaults in case they are missing
 ifeq ($(FSTRICT_ALIASING_WARNING_LEVEL),)
+  VANIR_ARM_OPT_LEVEL         ?= -O2
+  VANIR_THUMB_OPT_LEVEL       ?= -Os
   FSTRICT_ALIASING_WARNING_LEVEL := 2
 endif
 
@@ -55,6 +62,8 @@ ifeq ($(BONE_STOCK),true)
   USE_FSTRICT_FLAGS       :=
   USE_BINARY_FLAGS        :=
   USE_EXTRA_CLANG_FLAGS   :=
+  VANIR_ARM_OPT_LEVEL     := -O2
+  VANIR_THUMB_OPT_LEVEL   := -Os
   ADDITIONAL_TARGET_ARM_OPT   :=
   ADDITIONAL_TARGET_THUMB_OPT :=
 endif
@@ -79,8 +88,11 @@ ifeq ($(USE_GRAPHITE),true)
           -floop-block
 endif
 
-# fstrict-aliasing. Thumb is defaulted off for AOSP.
+# fstrict-aliasing. Thumb is defaulted off for AOSP. Use VANIR_SPECIAL_CASE_MODULES to
+# temporarily disable fstrict-aliasing locally until properly fixed.
 ifeq ($(USE_FSTRICT_FLAGS),true)
+    VANIR_SPECIAL_CASE_MODULES :=
+
   FSTRICT_FLAGS := \
           -fstrict-aliasing \
           -Wstrict-aliasing=$(FSTRICT_ALIASING_WARNING_LEVEL) \
@@ -114,6 +126,7 @@ VANIR_FSTRICT_OPTIONS := $(FSTRICT_FLAGS)
 VANIR_GLOBAL_CFLAGS += $(DEBUG_SYMBOL_FLAGS) $(DEBUG_FRAME_POINTER_FLAGS)
 VANIR_RELEASE_CFLAGS += $(DEBUG_SYMBOL_FLAGS) $(DEBUG_FRAME_POINTER_FLAGS)
 VANIR_CLANG_TARGET_GLOBAL_CFLAGS += $(DEBUG_SYMBOL_FLAGS) $(DEBUG_FRAME_POINTER_FLAGS)
+VANIR_GLOBAL_CPPFLAGS += $(DEBUG_SYMBOL_FLAGS) $(DEBUG_FRAME_POINTER_FLAGS)
 
 # set experimental/unsupported flags here for persistance and try to override local options that
 # may be set after release flags.  This option should not be used to set flags globally that are


### PR DESCRIPTION
optimization level flexibility
temp workaround handling for fstrict aliasing
add VANIR_GLOBAL_CPPFLAGS
add handling of output flags to select.mk

Change-Id: Ia89a608d726b47e28118d59db8142dcc57bd8787